### PR TITLE
Fix comment typo in state module

### DIFF
--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -174,7 +174,7 @@ class State:
         state = self.__dict__.copy()
         state['history'] = []
 
-        # Remove any view caching attributes. They'll be rebuilt frmo the
+        # Remove any view caching attributes. They'll be rebuilt from the
         # history after that gets reloaded.
         state.pop('_history_checksum', None)
         state.pop('_view', None)


### PR DESCRIPTION
## Summary
- fix typo in `State.__getstate__` comment

## Testing
- `git status --short`