### PR TITLE
Fix read_lines EOF handling

### DIFF
--- a/openhands/runtime/utils/files.py
+++ b/openhands/runtime/utils/files.py
@@ -63,7 +63,7 @@ def read_lines(all_lines: list[str], start: int = 0, end: int = -1) -> list[str]
             return all_lines[start:]
     else:
         num_lines = len(all_lines)
-        begin = max(0, min(start, num_lines - 2))
+        begin = max(0, min(start, num_lines - 1))
         end = -1 if end > num_lines else max(begin + 1, end)
         return all_lines[begin:end]
 
@@ -101,7 +101,7 @@ async def read_file(
 def insert_lines(
     to_insert: list[str], original: list[str], start: int = 0, end: int = -1
 ) -> list[str]:
-    """Insert the new content to the original content based on start and end"""
+    """Insert the new content to the original content based on start and end."""
     new_lines = [''] if start == 0 else original[:start]
     new_lines += [i + '\n' for i in to_insert]
     new_lines += [''] if end == -1 else original[end:]

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -64,3 +64,13 @@ def test_resolve_path():
         files.resolve_path('test.txt', '/workspace/test', HOST_PATH, CONTAINER_PATH)
         == Path(HOST_PATH) / 'test' / 'test.txt'
     )
+
+
+def test_read_lines_eof_exact_end():
+    lines = ['1\n', '2\n', '3\n']
+    assert files.read_lines(lines, start=2, end=3) == ['3\n']
+
+
+def test_read_lines_eof_overflow_end():
+    lines = ['1\n', '2\n', '3\n']
+    assert files.read_lines(lines, start=2, end=10) == ['3\n']


### PR DESCRIPTION
## Summary
- fix clamping logic in `read_lines`
- clarify docstring in `insert_lines`
- test reading at end-of-file

## Testing
- `ruff check openhands/runtime/utils/files.py tests/test_fileops.py`
- `pytest tests/test_fileops.py::test_read_lines_eof_exact_end tests/test_fileops.py::test_read_lines_eof_overflow_end` *(fails: command not found)*