### PR TITLE
Fix f-string backslash syntax errors

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -505,11 +505,14 @@ class BashSession:
         # Check if the command is a single command or multiple commands
         splited_commands = split_bash_commands(command)
         if len(splited_commands) > 1:
+            provided_cmds = "\n".join(
+                f"({i + 1}) {cmd}" for i, cmd in enumerate(splited_commands)
+            )
             return ErrorObservation(
                 content=(
-                    f'ERROR: Cannot execute multiple commands at once.\n'
-                    f'Please run each command separately OR chain them into a single command via && or ;\n'
-                    f'Provided commands:\n{"\n".join(f"({i + 1}) {cmd}" for i, cmd in enumerate(splited_commands))}'
+                    'ERROR: Cannot execute multiple commands at once.\n'
+                    'Please run each command separately OR chain them into a single command via && or ;\n'
+                    f'Provided commands:\n{provided_cmds}'
                 )
             )
 
@@ -597,8 +600,9 @@ class BashSession:
             logger.debug(
                 f'PANE CONTENT GOT after {time.time() - _start_time:.2f} seconds'
             )
-            logger.debug(f'BEGIN OF PANE CONTENT: {cur_pane_output.split("\n")[:10]}')
-            logger.debug(f'END OF PANE CONTENT: {cur_pane_output.split("\n")[-10:]}')
+            pane_lines = cur_pane_output.split("\n")
+            logger.debug(f'BEGIN OF PANE CONTENT: {pane_lines[:10]}')
+            logger.debug(f'END OF PANE CONTENT: {pane_lines[-10:]}')
             ps1_matches = CmdOutputMetadata.matches_ps1_metadata(cur_pane_output)
             current_ps1_count = len(ps1_matches)
 

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -922,11 +922,14 @@ class WindowsPowershellSession:
                 splited_cmds = [
                     str(s.Extent.Text) for s in statements
                 ]  # Try to get text
+                detected_cmds = "\n".join(
+                    f"({i + 1}) {cmd}" for i, cmd in enumerate(splited_cmds)
+                )
                 return ErrorObservation(
                     content=(
-                        f'ERROR: Cannot execute multiple commands at once.\n'
-                        f'Please run each command separately OR chain them into a single command via PowerShell operators (e.g., ; or |).\n'
-                        f'Detected commands:\n{"\n".join(f"({i + 1}) {cmd}" for i, cmd in enumerate(splited_cmds))}'
+                        'ERROR: Cannot execute multiple commands at once.\n'
+                        'Please run each command separately OR chain them into a single command via PowerShell operators (e.g., ; or |).\n'
+                        f'Detected commands:\n{detected_cmds}'
                     )
                 )
             elif statements.Count == 0 and not command.strip().startswith('#'):

--- a/tests/runtime/test_stress_remote_runtime.py
+++ b/tests/runtime/test_stress_remote_runtime.py
@@ -285,8 +285,9 @@ def test_stress_remote_runtime_long_output_with_soft_and_hard_timeout():
             mem_obs = runtime.run_action(mem_action)
             assert mem_obs.exit_code == 0
             _top_processes = [i.strip() for i in mem_obs.content.strip().split('\n')]
+            joined_processes = "- " + "\n- ".join(_top_processes)
             logger.info(
-                f'Top 5 memory-consuming processes (iteration {i}):\n{"- " + "\n- ".join(_top_processes)}'
+                f'Top 5 memory-consuming processes (iteration {i}):\n{joined_processes}'
             )
             iteration_stats['top_processes'] = _top_processes
 


### PR DESCRIPTION
## Summary
- fix invalid f-string expressions in bash helpers
- update windows bash helper accordingly
- adjust runtime stress test for new variable

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`